### PR TITLE
Use get-dois instead of custom DOI detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3649,6 +3649,11 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "get-dois": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-dois/-/get-dois-3.0.0.tgz",
+      "integrity": "sha512-xJHV5BT4dzUOtMgN77xVH83XQ5UQLvzQ0hWzDCTAgnRSvYeFy/q+DV7R220RSMCymssFqTzEWPpfbtkktvHdFA=="
+    },
     "get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "parcel-bundler": "^1.12.3"
   },
   "dependencies": {
+    "get-dois": "^3.0.0",
     "preact": "^8.4.2",
     "whatwg-fetch": "^3.0.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@
 import 'whatwg-fetch'
 
 import { h, render } from 'preact'
+import { getDois } from 'get-dois'
 import Tally from './components/Tally'
 
 const IS_DEV = typeof process !== 'undefined' && process.NODE_ENV === 'development'
@@ -31,56 +32,10 @@ function runRegexOnDoc (re, host) {
 // most scholarly articles have some kind of DOI meta
 // tag in the head of the document. Check these.
 function findDoiFromMetaTags () {
-  // collection of the various ways different publishers may
-  // indicate a given meta tag has the DOI.
-  const doiMetaNames = [
-    'citation_doi',
-    'doi',
-    'dc.doi',
-    'dc.identifier',
-    'dc.identifier.doi',
-    'bepress_citation_doi',
-    'rft_id',
-    'dcsext.wt_doi'
-  ]
-  const metas = document.querySelectorAll('meta')
-  let doi
+  const head = document.getElementsByTagName('head').item(0)
+  const dois = getDois(head)
 
-  metas.forEach(function (myMeta) {
-    if (!myMeta.name) {
-      return true // keep iterating
-    }
-
-    // has to be a meta name likely to contain a DOI
-    if (doiMetaNames.indexOf(myMeta.name.toLowerCase()) < 0) {
-      return true // continue iterating
-    }
-
-    // SAGE journals have weird meta tags with scheme='publisher-id'
-    // those DOIs have strange character replacements in them, so ignore.
-    // making universal rule cos i bet will help some other places too.
-    // eg:
-    //      http://journals.sagepub.com/doi/10.1207/s15327957pspr0203_4
-    //      http://journals.sagepub.com/doi/abs/10.1177/00034894991080S423
-    if (myMeta.scheme && myMeta.scheme !== 'doi') {
-      return true // continue iterating
-    }
-
-    // content has to look like a  DOI.
-    // much room for improvement here.
-    let doiCandidate = myMeta.content.replace('doi:', '').trim()
-    if (doiCandidate.indexOf('10.') === 0) {
-      doi = doiCandidate
-    }
-  })
-
-  if (!doi) {
-    return null
-  }
-  devLog('found a DOI from a meta tag', doi)
-
-  // all done.
-  return doi
+  return dois[0] || null
 }
 
 // sniff DOIs from the altmetric.com widget.


### PR DESCRIPTION
Was reminded of this today and had some spare time, so I figured I'd give this a try. This replaces the custom code for detecting a DOI from a page's `<head>` element with [get-dois](https://www.npmjs.com/package/get-dois), to share efforts with other projects.

Fixes #2.