### PR TITLE
change innerHTML to textContent for pubmed to prevent unexpected tag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ function findDoiFromPubmed () {
 
   const doiLinkElem = document.querySelectorAll("a[ref='aid_type=doi']")
   if (doiLinkElem.length) {
-    return doiLinkElem[0].innerHTML
+    return doiLinkElem[0].textContent
   }
 }
 


### PR DESCRIPTION
fix to #6 

This bugfix dosn't change the behavior in the standard case but improve the behavior in the case describe in #6 
I don't identify why there is different cases in pubmed but I fix this one.