### PR TITLE
[GH-671] add editorial notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,7 @@ Then the extension is in `extension`
 
 ## Developing ##
 
-Serve the root directory with a static file server:
-
-```
-$ python -m http.server 8001
-```
-
-Run the dev build:
-
-```
-$ npm run dev
-```
-
-Go to `http://localhost:8001`
-
-Note you will probabaly want to disable the 'real' extension if you have it installed! Otherwise they can conflict...
-
+Use the build you have run to sideload into firefox and chrome to test the extension
 
 ## Scite API Terms ##
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "author": "Scite Inc.",
   "version": "1.9.0",
   "manifest_version": 2,
-  "description": "See scite info around the web",
+  "description": "scite allow users to see how a scientific paper has been cited by providing the context of the citation and a classification describing whether it provides supporting or disputing evidence for the cited claim",
   "icons": {
     "16": "images/icons/16.png",
     "32": "images/icons/32.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6192,7 +6192,7 @@
       }
     },
     "scite-widget": {
-      "version": "github:scitedotai/scite-widget#7eb7ead2c35afad697959b4512f504d3a7979f42",
+      "version": "github:scitedotai/scite-widget#e61c2d3e75dd35440083aaff8657ed1b7bd92647",
       "from": "github:scitedotai/scite-widget#master",
       "requires": {
         "classnames": "^2.2.6",
@@ -6201,9 +6201,9 @@
       },
       "dependencies": {
         "query-string": {
-          "version": "6.13.2",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.2.tgz",
-          "integrity": "sha512-BMmDaUiLDFU1hlM38jTFcRt7HYiGP/zt1sRzrIWm5zpeEuO1rkbPS0ELI3uehoLuuhHDCS8u8lhFN3fEN4JzPQ==",
+          "version": "6.13.6",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.6.tgz",
+          "integrity": "sha512-/WWZ7d9na6s2wMEGdVCVgKWE9Rt7nYyNIf7k8xmHXcesPMlEzicWo3lbYwHyA4wBktI2KrXxxZeACLbE84hvSQ==",
           "requires": {
             "decode-uri-component": "^0.2.0",
             "split-on-first": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scite-extension",
   "version": "1.8.0",
-  "description": "scite inc web extension",
+  "description": "scite allow users to see how a scientific paper has been cited by providing the context of the citation and a classification describing whether it provides supporting or disputing evidence for the cited claim",
   "main": "index.js",
   "scripts": {
     "build": "./build.sh",

--- a/src/index.js
+++ b/src/index.js
@@ -210,8 +210,8 @@ function popupDoi (doi) {
   render(
     (
       <TallyLoader doi={doi}>
-        {({ tally }) => (
-          <Tally tally={tally} />
+        {({ tally, notices }) => (
+          <Tally tally={tally} notices={notices} />
         )}
       </TallyLoader>
     ),


### PR DESCRIPTION
# Change 

Add editorial notices to scite extension

ToDo:
- [ ] Release it

# Pics

## Chrome

<img width="1497" alt="Screen Shot 2020-10-30 at 2 12 08 PM" src="https://user-images.githubusercontent.com/15069938/97736301-39269080-1aba-11eb-944d-b481bf5f87b3.png">


## Firefox

<img width="1085" alt="Screen Shot 2020-10-30 at 2 17 44 PM" src="https://user-images.githubusercontent.com/15069938/97736611-bce07d00-1aba-11eb-8460-1997cf634bfd.png">
