### PR TITLE
[hotfix] reset text indent for wikipedia

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ const BADGE_SCRIPT = `
 <style>
 .scite-badge {
   margin-left: 0.25rem;
+  text-indent: 0;
 }
 </style>
 <link rel="stylesheet" type="text/css" href="https://cdn.scite.ai/badge/scite-badge-latest.min.css">


### PR DESCRIPTION
# Change

some wikipedia pages use this weird styling property and set it to -3.2rem which makes the styling off.


In the future I am considering adding this to the badges themselves add a style reset but for now I will leave it as is.