### PR TITLE
Update badge code to use latest

### DIFF
--- a/src/badges.js
+++ b/src/badges.js
@@ -2,7 +2,7 @@
 const queryString = require('query-string')
 
 const BADGE_SCRIPT = `
-<script async type="application/javascript" src="https://cdn.scite.ai/badge/scite-badge-v5.2.2.min.js">
+<script async type="application/javascript" src="https://cdn.scite.ai/badge/scite-badge-latest.min.js?v=2">
 </script>`
 
 function createBadge (doi) {


### PR DESCRIPTION
It looks like we are using a pinned version for the badge which maybe a hangover from when we were worried about CSS mismatch, which should no longer be an issue.