### PR TITLE
[hotfix] ensure we support nature news and journal articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Search: https://elifesciences.org/articles/62456#references
 #### nature.com
 
 Result: https://www.nature.com/articles/s41467-020-19171-4
+
+News Result: https://www.nature.com/articles/d41586-021-00958-4
 #### scholar.google.com
 
 Search: https://scholar.google.com/scholar?hl=en&as_sdt=0%2C5&q=Citation+contexts&btnG=

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Scite",
   "author": "Scite Inc.",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "manifest_version": 2,
   "description": "scite allows users to see how a publication has been cited, providing the citation context and classification",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scite-extension",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scite-extension",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "scite allow users to see how a scientific paper has been cited by providing the context of the citation and a classification describing whether it provides supporting or contrasting evidence for the cited claim",
   "main": "index.js",
   "watch": {

--- a/src/badges.js
+++ b/src/badges.js
@@ -273,8 +273,11 @@ function findELifeSciencesDOIs () {
 function findNatureDOIs () {
   const els = []
   const cites = [
+    ...document.body.querySelectorAll('.c-article-references__item'),
     ...document.body.querySelectorAll('.c-reading-companion__reference-item'),
-    ...document.body.querySelectorAll('[itemprop="citation"]')
+    ...document.body.querySelectorAll('[itemprop="citation"]'),
+    ...document.body.querySelectorAll('.js-ref-item')
+
   ]
   for (const cite of cites) {
     const anchors = cite.querySelectorAll('a')


### PR DESCRIPTION
# Change

News articles have different references than Journal articles in Nature. Let's support them

<img width="770" alt="Screen Shot 2021-04-14 at 3 35 35 PM" src="https://user-images.githubusercontent.com/15069938/114762053-af047880-9d37-11eb-9e40-87556cad6d72.png">
<img width="1272" alt="Screen Shot 2021-04-14 at 3 32 23 PM" src="https://user-images.githubusercontent.com/15069938/114762055-af047880-9d37-11eb-81f5-4a97ce295d39.png">
