### PR TITLE
[hotfix] clean up google doi url captures

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Scite",
   "author": "Scite Inc.",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "manifest_version": 2,
   "description": "scite allows users to see how a publication has been cited, providing the citation context and classification",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "scite-extension",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scite-extension",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "scite allow users to see how a scientific paper has been cited by providing the context of the citation and a classification describing whether it provides supporting or contrasting evidence for the cited claim",
   "main": "index.js",
   "watch": {

--- a/src/badges.js
+++ b/src/badges.js
@@ -339,11 +339,15 @@ function findGoogleDOIs () {
   for (const cite of cites) {
     const anchors = cite.querySelectorAll('a')
     for (const anchor of anchors) {
-      const doi = anchor?.href?.match(/10\.(.+)/)
-      if (doi && doi.length > 1) {
+      const doi = anchor?.href?.match(DOI_REGEX)
+      if (doi && doi.length > 0) {
+        let cleanDOI = decodeURIComponent(doi[0])
+        for (const ending of ['/full/html', '/html', '/abstract', '/full', '.pdf', '/pdf']) {
+          cleanDOI = cleanDOI.replace(ending, '')
+        }
         els.push({
           citeEl: cite,
-          doi: decodeURIComponent(doi[0])
+          doi: cleanDOI
         })
         break
       }


### PR DESCRIPTION
# Change

Unlike other places, google scholar and google URLs present heterogenious URI schemes. I have changed the capture to be DOI only with a bit of scrubbing heursitics based on what I saw ie. ('/full' in frontiers URLs etc.)

I went through a bunch of searches and this really improves badges on google scholar, i couldn't find any other heursitics to strip off but I am sure we will encounter more.

