### PR TITLE
[hotfix] add apa results and search and fix badge sticking around on apa / SPAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,11 @@ result: https://jcircadianrhythms.biomedcentral.com/articles/10.1186/1740-3391-1
 #### scielo
 
 search: https://search.scielo.org/?q=robotics&lang=en&count=15&from=0&output=site&sort=YEAR_ASC&format=summary&fb=&page=1
+
+# APA Psychnet
+
+Search:
+https://psycnet.apa.org/search/results?id=56ab4ce0-0f51-85fc-7298-3e65d0f31e18&tab=PA&sort=CitedByCountSort1%20desc,PublicationYearMSSort%20desc&display=25&page=1
+
+Fulltext references:
+https://psycnet.apa.org/fulltext/2015-00298-001.html

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Scite",
   "author": "Scite Inc.",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "manifest_version": 2,
   "description": "scite allows users to see how a publication has been cited, providing the citation context and classification",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "scite-extension",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scite-extension",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "scite allow users to see how a scientific paper has been cited by providing the context of the citation and a classification describing whether it provides supporting or contrasting evidence for the cited claim",
   "main": "index.js",
   "watch": {

--- a/src/badges.js
+++ b/src/badges.js
@@ -79,7 +79,7 @@ const largeMarginMinStyle = `
 .scite-badge {
   display: block;
   width: min-content;
-  margin: 0.5rem 0;
+  margin: 0.5rem 0 !important;
 }
 </style>
 `
@@ -948,12 +948,35 @@ function findBMCDOIs () {
 }
 
 /**
- * findBMCDOIs looks in reference links to DOI.
+ * findScieloDOIs looks in reference links to DOI.
  * @returns {Array<{ citeEl: Element, doi: string}>} - Return
  */
 function findScieloDOIs () {
   const els = []
   const cites = document.body.querySelectorAll('.metadata')
+  for (const cite of cites) {
+    const anchors = cite.querySelectorAll('a')
+    for (const anchor of anchors) {
+      const doi = decodeURIComponent(anchor?.href).match(DOI_REGEX)
+      if (doi) {
+        els.push({
+          citeEl: cite,
+          doi: decodeURIComponent(doi[0])
+        })
+        break
+      }
+    }
+  }
+  return els
+}
+
+/**
+ * findAPADOIs looks in reference links to DOI.
+ * @returns {Array<{ citeEl: Element, doi: string}>} - Return
+ */
+function findAPADOIs () {
+  const els = []
+  const cites = document.body.querySelectorAll('.resultData, .citText')
   for (const cite of cites) {
     const anchors = cite.querySelectorAll('a')
     for (const anchor of anchors) {
@@ -1221,6 +1244,12 @@ const BADGE_SITES = [
     }
     </style>
 `
+  },
+  {
+    name: 'apa.org',
+    findDoiEls: findAPADOIs,
+    position: 'afterend',
+    style: largeMarginMinStyle
   }
 ]
 

--- a/src/badges.js
+++ b/src/badges.js
@@ -1264,6 +1264,11 @@ export default function insertBadges () {
     return
   }
 
+  const badges = document.querySelectorAll('.scite-badge')
+  for (const badge of badges) {
+    badge.remove()
+  }
+
   const els = badgeSite.findDoiEls()
   if (!els || els.length <= 0) {
     return


### PR DESCRIPTION
# Change

Add to APA results and search

Add a mutation observer for route changes so that if its a dynamically routed SPA we reload the page. 

Fixes a badge issue with APA where the metatag sticks around by introducing a restricted path notion.


# Testing

- Test on the APA results and search provided in the readme
- Click around to search from a APA page with a badge. It shouldn't have a badge sticking around
- Other things should work as normal.