### PR TITLE
[fix scitedotai/scite#2657] Fix researchgate popup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,12 +106,14 @@ function findDoiFromMetaTags () {
   let doi
 
   metas.forEach(function (myMeta) {
-    if (!myMeta.name) {
+    const name = myMeta.name || myMeta.getAttribute('property')
+
+    if (!name) {
       return true // keep iterating
     }
 
     // has to be a meta name likely to contain a DOI
-    if (doiMetaNames.indexOf(myMeta.name.toLowerCase()) < 0) {
+    if (doiMetaNames.indexOf(name.toLowerCase()) < 0) {
       return true // continue iterating
     }
 


### PR DESCRIPTION
Fixes: https://github.com/scitedotai/scite/issues/2657

The DOI is provided at `dc.identifier` but it is the meta tag `property` attribute rather than `name` here: https://www.researchgate.net/publication/336759980_Identification_of_a_Synergistic_Multi-Drug_Combination_Active_in_Cancer_Cells_via_the_Prevention_of_Spindle_Pole_Clustering