### PR TITLE
GH 3921/add support for ads

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Scite",
   "author": "Scite Inc.",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "manifest_version": 2,
   "description": "scite allows users to see how a publication has been cited, providing the citation context and classification",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scite-extension",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scite-extension",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scite-extension",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "scite allow users to see how a scientific paper has been cited by providing the context of the citation and a classification describing whether it provides supporting or contrasting evidence for the cited claim",
   "main": "index.js",
   "scripts": {

--- a/src/badges.js
+++ b/src/badges.js
@@ -365,8 +365,9 @@ function findSpringerDOIs () {
 }
 
 function getGoogleScholarRef (cite) {
-  const title = cite.querySelector('.gs_rt')?.textContent
-  const authors = cite.querySelector('.gs_a')?.textContent.split('-')[0]
+  const title = cite.querySelector('.gs_rt')?.textContent || cite.querySelector('.gsc_a_at')?.textContent
+  const authors = cite.querySelector('.gs_a')?.textContent.split('-')[0] || cite.querySelector('.gs_gray')?.textContent
+  console.log(title, authors)
 
   if (!title || !authors) {
     return null
@@ -413,7 +414,7 @@ function getGoogleRef (cite) {
  */
 function findGoogleScholarDOIs () {
   const els = []
-  const cites = [...document.body.querySelectorAll('.rc'), ...document.body.querySelectorAll('.gs_r')]
+  const cites = [...document.body.querySelectorAll('.rc'), ...document.body.querySelectorAll('.gs_r'), ...document.body.querySelectorAll('.gsc_a_t')]
   for (const cite of cites) {
     const embeddedDOI = getAnchorDOI(cite)
     if (embeddedDOI) {
@@ -1154,7 +1155,7 @@ const BADGE_SITES = [
   {
     name: 'scholar.google',
     findDoiEls: findGoogleScholarDOIs,
-    position: 'afterend',
+    position: 'beforeend',
     style: commonMinStyle
   },
   {

--- a/src/badges.js
+++ b/src/badges.js
@@ -367,7 +367,6 @@ function findSpringerDOIs () {
 function getGoogleScholarRef (cite) {
   const title = cite.querySelector('.gs_rt')?.textContent || cite.querySelector('.gsc_a_at')?.textContent
   const authors = cite.querySelector('.gs_a')?.textContent.split('-')[0] || cite.querySelector('.gs_gray')?.textContent
-  console.log(title, authors)
 
   if (!title || !authors) {
     return null

--- a/src/badges.js
+++ b/src/badges.js
@@ -1361,9 +1361,18 @@ const BADGE_SITES = [
   }
 ]
 
+// We don't want badges on these sites.
+// Sometimes we need to explicitly exclude them
+// so we can remain general to other paths
+// and subdomains on the same domain.
+const NON_BADGE_SITES = [
+  'mail.google'
+]
+
 export default async function insertBadges () {
   const badgeSite = BADGE_SITES.find(site => window.location.href.includes(site.name))
-  if (!badgeSite) {
+  const nonBadgeSite = NON_BADGE_SITES.find(site => window.location.href.includes(site))
+  if (!badgeSite || nonBadgeSite) {
     return
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -218,6 +218,14 @@ function findDoiFromPsycnet () {
   return runRegexOnDoc(DOI_REGEX, 'psycnet.apa.org')
 }
 
+function findDoiFromADS () {
+  // exampleh: ttps://ui.adsabs.harvard.edu/abs/2011TJSAI..26..166M/abstract
+  const dataTarget = document.querySelectorAll('*[data-target="DOI"]')
+  if (dataTarget.length) {
+    return dataTarget[0]?.textContent
+  }
+}
+
 function findDoiFromTitle () {
   // Crossref DOI regex. See https://www.crossref.org/blog/dois-and-matching-regular-expressions/
   const re = DOI_REGEX
@@ -257,6 +265,7 @@ async function findDoiFromPDF () {
 async function findDoi () {
   // we try each of these functions, in order, to get a DOI from the page.
   const doiFinderFunctions = [
+    findDoiFromADS,
     findDoiFromMetaTags,
     findDoiFromDataDoiAttributes,
     findDoiFromScienceDirect,
@@ -353,6 +362,7 @@ function runWithDelay () {
   if (popupRef) {
     popupRef.remove()
   }
+  poppedUp = false
 
   let delay = 200
 

--- a/src/index.js
+++ b/src/index.js
@@ -289,7 +289,6 @@ async function findDoi () {
 
   for (let i = 0; i < doiFinderFunctions.length; i++) {
     const myDoi = doiFinderFunctions[i]()
-    console.log(myDoi)
     if (myDoi && `${myDoi}`.startsWith('10.')) {
       // if we find a good DOI, stop looking
       return myDoi

--- a/src/index.js
+++ b/src/index.js
@@ -219,10 +219,19 @@ function findDoiFromPsycnet () {
 }
 
 function findDoiFromADS () {
-  // exampleh: ttps://ui.adsabs.harvard.edu/abs/2011TJSAI..26..166M/abstract
+  // exampleh: https://ui.adsabs.harvard.edu/abs/2011TJSAI..26..166M/abstract
   const dataTarget = document.querySelectorAll('*[data-target="DOI"]')
   if (dataTarget.length) {
     return dataTarget[0]?.textContent
+  }
+}
+
+function findDoiFromJSTOR () {
+  // exampleh: https://www.jstor.org/stable/1340219
+  const dataTarget = document.querySelectorAll('*[data-qa="crossref-doi"]')
+  if (dataTarget.length) {
+    const doi = dataTarget[0]?.textContent.match(DOI_REGEX)
+    return doi
   }
 }
 
@@ -266,6 +275,7 @@ async function findDoi () {
   // we try each of these functions, in order, to get a DOI from the page.
   const doiFinderFunctions = [
     findDoiFromADS,
+    findDoiFromJSTOR,
     findDoiFromMetaTags,
     findDoiFromDataDoiAttributes,
     findDoiFromScienceDirect,
@@ -279,6 +289,7 @@ async function findDoi () {
 
   for (let i = 0; i < doiFinderFunctions.length; i++) {
     const myDoi = doiFinderFunctions[i]()
+    console.log(myDoi)
     if (myDoi && `${myDoi}`.startsWith('10.')) {
       // if we find a good DOI, stop looking
       return myDoi


### PR DESCRIPTION
- [GH-3879] ensure that gmail does not have badges injected (it doesn't look good)
- [GH-3921] add ads work around and fix poppedup state for SPAs 
ADS actually has a broken metadata section so metadata for citation_doi were just not working. I added a work around using the page DOI for now.

Also I noticed that SPAs were a bit broken because the popped up state was not getting reset! So when you reroute a new popup was not getting created! I fixed that as well.

Testing:

For ADS go here:
-https://ui.adsabs.harvard.edu/abs/2022FrPhy..1734501X/abstract
- search somethign new
- click a few links and ensure the badge changes!
- sometimes the badge stays due to their SPA bug.

For JSTOR go here: 
- https://github.com/scitedotai/scite/issues/3921
- Other JSTOR articles work anyway