### PR TITLE
[GH-4216] remove semantic scholar badges and improve badge clearing

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Scite",
   "author": "Scite Inc.",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "manifest_version": 2,
   "description": "scite allows users to see how a publication has been cited, providing the citation context and classification",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "scite-extension",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.34.0",
+      "version": "1.34.1",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.1",

--- a/src/index.js
+++ b/src/index.js
@@ -47,8 +47,7 @@ const LONG_DELAY_HOSTS = [
   'europepmc.org',
   'orcid.org',
   'connectedpapers.com',
-  'lens.org',
-  'www.semanticscholar.org'
+  'lens.org'
 ]
 
 const SCITE_HOSTS = [


### PR DESCRIPTION
Based on https://github.com/scitedotai/scite-extension/issues/64 

Part of this is inadvertanly removing badge removal during the last PR.

We need to remove semantic scholar badges for now because they are being problematic:
1. They stick around on layout changes in semantic scholar (I haven't though of a way to solve this)
2. Asyncly injected badges after changing the page get inserted in wrong places (I have solved this by changing when we insert badges to be more robust)

We can consider adding badges for semantic scholar and solving 1 later.