### PR TITLE
[hotfix] Include font files for badge

### DIFF
--- a/src/badge/main.js
+++ b/src/badge/main.js
@@ -5,6 +5,7 @@ import SectionTally from '../components/SectionTally'
 import { fetchNotices, fetchTallies, fetchSectionTallies } from './scite'
 import Tooltip from '../components/Tooltip'
 import '../styles/index.css'
+import '../styles/typography.css'
 
 const BATCH_SIZE = 500
 


### PR DESCRIPTION
Trying this locally in incognito it seems to work... I think in the transition to the mega repo this file must have accidentally gotten unincluded.

Pushing to stage to test there. Locally I see that now the icon font is downloaded in private mode.

/Cc @u-ashish 