### PR TITLE
[scitedotai/scite#5699] Change search link to assistant one

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -21,7 +21,7 @@ function onCreated () {
 
 browser.contextMenus.create({
   id: 'scite-citation-search',
-  title: 'Search scite.ai citation statements',
+  title: 'Ask scite.ai assistant',
   contexts: ['selection']
 }, onCreated)
 
@@ -33,7 +33,7 @@ browser.contextMenus.onClicked.addListener(function (info, tab) {
       )
 
       browser.tabs.create({
-        url: `https://scite.ai/search/citations?q=${encodedSelection}&utm_source=generic&utm_medium=plugin&utm_campaign=plugin-citation-search`
+        url: `https://scite.ai/assistant?startTerm=${encodedSelection}&utm_source=generic&utm_medium=plugin&utm_campaign=plugin-citation-search`
       })
     }
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/815831/233455603-fcc2a8c4-0168-4b52-b233-85b44feaf949.png)

We may also consider changing the utm_campaign:

```
&utm_source=generic&utm_medium=plugin&utm_campaign=plugin-citation-search
```

Not sure what would be most helpful there but this leaves it the same rn

/Cc @jmnicholson @u-ashish 