### PR TITLE
[hotfix] add popper core depedency

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Scite",
   "author": "Scite Inc.",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "manifest_version": 2,
   "description": "scite allows users to see how a publication has been cited, providing the citation context and classification",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "scite-extension",
-  "version": "1.34.4",
+  "version": "1.36.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scite-extension",
-      "version": "1.34.4",
+      "version": "1.36.1",
       "license": "MIT",
       "dependencies": {
+        "@popperjs/core": "^2.11.8",
         "classnames": "^2.3.2",
         "jest": "^29.5.0",
         "jest-fetch-mock": "^3.0.3",
@@ -1562,10 +1563,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
-      "peer": true,
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -16494,10 +16494,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
-      "peer": true
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@sinclair/typebox": {
       "version": "0.25.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scite-extension",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "description": "scite allow users to see how a scientific paper has been cited by providing the context of the citation and a classification describing whether it provides supporting or contrasting evidence for the cited claim",
   "main": "index.js",
   "scripts": {
@@ -54,6 +54,7 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
+    "@popperjs/core": "^2.11.8",
     "classnames": "^2.3.2",
     "jest": "^29.5.0",
     "jest-fetch-mock": "^3.0.3",


### PR DESCRIPTION
If mozilla still has an issue after using `npm ci` before build - I have seen online that a few people add the popper/core depdency to ensure that dependency is actually existing.

