### PR TITLE
SCITE-1045 | Add optional use-test-env flag to point to scite staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ To use simply include the Javascript bundle on your page. All elements with the 
 
 `chart-type`: What type of chart you want to show for the Section Tally widget. Must be one of `bar`, `pie`, `donut`. Defaults to `null`.
 
+`use-test-env`: Set to `'true'` if you want to point to `staging.scite.ai`. Defaults to false. This should never be used in production.
+
 To pull the target DOI from a meta tag in the document rather than setting inline, you can use the syntax `meta:my_tag_name`. For example:
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scite-extension",
-  "version": "1.36.2",
+  "version": "1.36.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scite-extension",
-      "version": "1.36.2",
+      "version": "1.36.3",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scite-extension",
-  "version": "1.36.2",
+  "version": "1.36.3",
   "description": "scite allow users to see how a scientific paper has been cited by providing the context of the citation and a classification describing whether it provides supporting or contrasting evidence for the cited claim",
   "main": "index.js",
   "scripts": {

--- a/src/badge/main.js
+++ b/src/badge/main.js
@@ -98,7 +98,7 @@ export function getConfig (el) {
   }
 
   if (data.useTestEnv) {
-    config.useTestEnv = data.useTestEnv == 'true'
+    config.useTestEnv = data.useTestEnv === 'true'
   }
 
   return config

--- a/src/badge/main.js
+++ b/src/badge/main.js
@@ -97,6 +97,10 @@ export function getConfig (el) {
     config.showTotal = data.showTotal === 'true'
   }
 
+  if (data.useTestEnv) {
+    config.useTestEnv = data.useTestEnv == 'true'
+  }
+
   return config
 }
 

--- a/src/components/SectionTally.js
+++ b/src/components/SectionTally.js
@@ -13,7 +13,7 @@ const SectionTally = ({
   source, campaign, autologin, rewardfulID,
   tally, forceCollapse, showLabels,
   small = false, horizontal = false, isBadge = false, showZero = true,
-  chartType = null, showLogo = true
+  chartType = null, showLogo = true, useTestEnv = false
 }) => {
   const params = {
     utm_medium: isBadge ? 'badge' : 'plugin',
@@ -28,6 +28,8 @@ const SectionTally = ({
   if (rewardfulID) {
     params.via = rewardfulID
   }
+
+  const sciteBaseUrl = useTestEnv ? 'https://staging.scite.ai' : 'https://scite.ai'
 
   const queryString = qs.stringify(params)
 
@@ -48,7 +50,7 @@ const SectionTally = ({
   const discussion = (tally && tally.discussion && tally.discussion.toLocaleString()) || 0
   const other = (tally && tally.other && tally.other.toLocaleString()) || 0
 
-  const reportLink = `https://scite.ai/reports/${tally && tally.doi}?${queryString}`
+  const reportLink = `${sciteBaseUrl}/reports/${tally && tally.doi}?${queryString}`
   const handleClick = () => {
     window.open(reportLink)
   }

--- a/src/components/Tally.js
+++ b/src/components/Tally.js
@@ -40,7 +40,7 @@ const Tally = ({
   source, campaign, autologin, rewardfulID,
   tally, forceCollapse, showLabels, notices,
   small = false, horizontal = false, isBadge = false, showZero = true,
-  showLogo = true, showTotal = true, showCites = true
+  showLogo = true, showTotal = true, showCites = true, useTestEnv = false
 }) => {
   const params = {
     utm_medium: isBadge ? 'badge' : 'plugin',
@@ -55,6 +55,8 @@ const Tally = ({
   if (rewardfulID) {
     params.via = rewardfulID
   }
+
+  const sciteBaseUrl = useTestEnv ? 'https://staging.scite.ai' : 'https://scite.ai'
 
   const queryString = qs.stringify(params)
 
@@ -78,7 +80,7 @@ const Tally = ({
   const noticeCount = editorialNotices.length.toLocaleString() || 0
 
   const handleClick = () => {
-    window.open(`https://scite.ai/reports/${tally && tally.doi}?${queryString}`)
+    window.open(`${sciteBaseUrl}/reports/${tally && tally.doi}?${queryString}`)
   }
 
   return (

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -99,23 +99,23 @@ const Message = ({ className }) => (
   </div>
 )
 
-const TooltipContent = ({ tally, notices, showTotal }) => (
+const TooltipContent = ({ tally, notices, showTotal, sciteBaseUrl }) => (
   <div className={styles.tooltipContent}>
     <img className={styles.logo} src='https://cdn.scite.ai/assets/images/logo.svg' />
     <span className={styles.slogan}>Smart Citations</span>
 
     <Tally tally={tally} notices={notices} showTotal={showTotal} />
-    {tally && <a className={styles.button} href={`https://scite.ai/reports/${tally.doi}`} target='_blank' rel='noopener noreferrer'>View Citations</a>}
+    {tally && <a className={styles.button} href={`${sciteBaseUrl}/reports/${tally.doi}`} target='_blank' rel='noopener noreferrer'>View Citations</a>}
     <Message />
   </div>
 )
 
-const SectionTallyTooltipContent = ({ tally }) => (
+const SectionTallyTooltipContent = ({ tally, sciteBaseUrl }) => (
   <div>
     <img className={styles.logo} src='https://cdn.scite.ai/assets/images/logo.svg' />
     <span className={styles.slogan}>Cited in Sections</span>
     <SectionTally tally={tally} />
-    {tally && <a className={styles.button} href={`https://scite.ai/reports/${tally.doi}`} target='_blank' rel='noopener noreferrer'>View Citations</a>}
+    {tally && <a className={styles.button} href={`${sciteBaseUrl}/reports/${tally.doi}`} target='_blank' rel='noopener noreferrer'>View Citations</a>}
     <Message />
   </div>
 )
@@ -131,7 +131,8 @@ const TooltipPopper = ({
   handleMouseEnter,
   handleMouseLeave,
   tallyType,
-  showTotal
+  showTotal,
+  sciteBaseUrl
 }) => {
   let updatePosition
   // XXX: Hack to fix positioning on first load, sorry
@@ -142,7 +143,7 @@ const TooltipPopper = ({
   }, [tally])
 
   const handleClickTooltip = () => {
-    window.open(`https://scite.ai/reports/${doi}`)
+    window.open(`${sciteBaseUrl}/reports/${doi}`)
   }
 
   return (
@@ -189,8 +190,8 @@ const TooltipPopper = ({
             onMouseLeave={handleMouseLeave}
             onClick={handleClickTooltip}
           >
-            {tallyType === 'smart_citations' && (<TooltipContent tally={tally} notices={notices} showTotal={showTotal} />)}
-            {tallyType === 'sections' && (<SectionTallyTooltipContent tally={tally} />)}
+            {tallyType === 'smart_citations' && (<TooltipContent tally={tally} notices={notices} showTotal={showTotal} sciteBaseUrl={sciteBaseUrl} />)}
+            {tallyType === 'sections' && (<SectionTallyTooltipContent tally={tally} sciteBaseUrl={sciteBaseUrl} />)}
           </div>
         )
       }}
@@ -208,11 +209,14 @@ export const Tooltip = ({
   slide = 0,
   children,
   tallyType = 'smart_citations',
-  showTotal = true
+  showTotal = true,
+  useTestEnv = false
 }) => {
   const [showTooltip, setShowTooltip] = useState(false)
   let hideTooltipIntvl
   let showTooltipIntvl
+
+  const sciteBaseUrl = useTestEnv ? 'https://staging.scite.ai' : 'https://scite.ai'
 
   const handleMouseEnter = () => {
     if (placement === 'none') {
@@ -270,6 +274,7 @@ export const Tooltip = ({
         handleMouseLeave={handleMouseLeave}
         tallyType={tallyType}
         showTotal={showTotal}
+        sciteBaseUrl={sciteBaseUrl}
       />
     </Manager>
   )


### PR DESCRIPTION
As part of we want the AG team to be able to point to scite staging in their test environment.

- Add `use-test-env` as an optional flag we pick up from the `el.dataset`
- When it is set to `'true'`, we point to `staging.scite.ai` as the baseUrl
- By default, this flag is set to `false` so it always points to production.
- Update README
- Bump package version

## TODO

I think after merging I just have to deploy it to staging and prod by tagging and that's it right?
