### PR TITLE
[noref] For smart_citations, include citingPublications count when deciding whether there are tallies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scite-extension",
-  "version": "1.36.4",
+  "version": "1.36.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scite-extension",
-      "version": "1.36.4",
+      "version": "1.36.5",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scite-extension",
-  "version": "1.36.4",
+  "version": "1.36.5",
   "description": "scite allow users to see how a scientific paper has been cited by providing the context of the citation and a classification describing whether it provides supporting or contrasting evidence for the cited claim",
   "main": "index.js",
   "scripts": {

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -248,6 +248,8 @@ export const Tooltip = ({
     return children
   }
 
+  // This is a hack because section tallies don't return citingPublications
+  const hasZeroCites = tallyType === 'smart_citations' ? (tally && tally.total === 0 && tally.citingPublications === 0) : tally && tally.total === 0
   return (
     <Manager>
       <Reference>
@@ -263,7 +265,7 @@ export const Tooltip = ({
         )}
       </Reference>
       <TooltipPopper
-        show={showTooltip && !(tally && tally.total === 0 && !showZero)}
+        show={showTooltip && !(hasZeroCites && !showZero)}
         doi={doi}
         tally={tally}
         notices={notices}


### PR DESCRIPTION
With the Smart Citations badge, when users disable `showZero`, the tooltip will be missing when `citingPublications > 0` but `tally = 0` (note that `tally` represents the sum of smart cites, not dumb cites).

To see it happen on prod:
- go to https://scite.ai/badge
- for the smart cite badge, use the DOI=10.1016/j.biopsych.2005.08.012
- the tallies are there, tooltip will work

now, try again:
- use DOI=10.1097/MOU.0000000000000026
- note that there are 2 dumb cites but 0 smart cites
- badge will show but tooltip will not

this is because the check to showTooltip uses just `tally.total` when it should also factor in `tally.citingPublications`. Unfortunately the section tally doesn't return that right now, so add a conditional to check accordingly based on the tally type to avoid any regressions.