### PR TITLE
[hotfix] update to manifest v3

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Scite",
   "author": "Scite Inc.",
-  "version": "1.36.2",
-  "manifest_version": 2,
+  "version": "1.36.3",
+  "manifest_version": 3,
   "description": "scite allows users to see how a publication has been cited, providing the citation context and classification",
   "icons": {
     "16": "images/icons/16.png",
@@ -27,8 +27,8 @@
       ]
     }
   ],
-  "background" : {
-    "scripts" : ["background.js"]
+  "background": {
+    "service_worker": "background.js"
   },
   "externally_connectable": {
     "matches": [
@@ -37,11 +37,21 @@
     ]
   },
   "permissions": [
-    "https://api.scite.ai/*",
     "contextMenus",
     "storage"
   ],
   "web_accessible_resources": [
-    "fonts/*"
+    {
+      "resources": [
+        "fonts/*"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
+    }
+  ],
+  "content_security_policy": {},
+  "host_permissions": [
+    "https://api.scite.ai/*"
   ]
 }


### PR DESCRIPTION
Works in Chrome
- [x] service worker changes
- [x] non-service worker 

<img width="1175" alt="Screenshot 2024-10-15 at 1 00 11 PM" src="https://github.com/user-attachments/assets/b84ed5ca-8abb-4b22-a0cb-a6bd17347aca">
- [x] Badge Insertion 
- [x] Showing badge
- [x] Context Menu
<img width="652" alt="Screenshot 2024-10-15 at 1 00 43 PM" src="https://github.com/user-attachments/assets/6eb42b5d-acb6-4a30-acc1-af2f1b84b188">


Something weird with web-ext and other browsers to working that out ATM.

