### PR TITLE
Fix s.replaceAll error

### DIFF
--- a/src/components/Count.js
+++ b/src/components/Count.js
@@ -2,6 +2,7 @@ import React from 'react'
 import classNames from 'classnames'
 import Icon from './Icon'
 import styles from '../styles/Count.css'
+import { getCountNumber } from '../util/getCountNumber'
 
 export const Count = ({ className, horizontal, type, count, showLabels = false, small = false, verticalCompact = false }) => (
   <div
@@ -48,10 +49,10 @@ export const Count = ({ className, horizontal, type, count, showLabels = false, 
           <div className={styles.numberContainer}>
             <span className={classNames(styles.number, styles.largeNumber,
               {
-                [styles.number1k]: Number(count.replaceAll(',', '')) > 1000,
-                [styles.number10k]: Number(count.replaceAll(',', '')) > 10000,
-                [styles.number100k]: Number(count.replaceAll(',', '')) > 100000,
-                [styles.number1m]: Number(count.replaceAll(',', '')) > 1000000
+                [styles.number1k]: getCountNumber(count) > 1000,
+                [styles.number10k]: getCountNumber(count) > 10000,
+                [styles.number100k]: getCountNumber(count) > 100000,
+                [styles.number1m]: getCountNumber(count) > 1000000
               }
             )}
             >

--- a/src/util/getCountNumber.js
+++ b/src/util/getCountNumber.js
@@ -1,0 +1,5 @@
+export const getCountNumber = (count) => {
+  return typeof count === 'number'
+    ? count
+    : typeof count === 'string' ? Number(count.replaceAll(',', '')) : count
+}


### PR DESCRIPTION
### Fixing a bug discovered on `vertical-compact` mode when `count` value was not a String

![image](https://github.com/user-attachments/assets/221f2f39-9a48-4b1e-bf6b-2de8c4f2a254)

<hr>

Adding functionality to check `count` value and return it as Number. It helps to prevent errors when count is not a String and tries to use the `replaceAll()` string method.

![image](https://github.com/user-attachments/assets/8d7fa741-b18d-4345-a01c-3666dd1ffdff)



