### PR TITLE
remove id for a11y when multiple badges

### DIFF
--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -105,7 +105,7 @@ const TooltipContent = ({ tally, notices, showTotal, sciteBaseUrl }) => (
     <span className={styles.slogan}>Smart Citations</span>
 
     <Tally tally={tally} notices={notices} showTotal={showTotal} />
-    {tally && <a id='view-citations-button' className={styles.button} href={`${sciteBaseUrl}/reports/${tally.doi}`} target='_blank' rel='noopener noreferrer'>View Citations</a>}
+    {tally && <a className={styles.button} href={`${sciteBaseUrl}/reports/${tally.doi}`} target='_blank' rel='noopener noreferrer'>View Citations</a>}
     <Message />
   </div>
 )


### PR DESCRIPTION
https://scan.userway.org/public/violation/5496607498919725488

user way doesn't like there there are multiple ids of the same kind. I removed the id completely because there is no need for multiple badges on the same page. @domenicrosati would you agree?