### PR TITLE
[HOLD] Fix background.js implicit global assignment breaking Chrome MV3 service worker

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,5 @@
 /* global chrome */
-var browser = chrome
+const browser = chrome
 
 browser.runtime.onInstalled.addListener(function (details) {
   if (details.reason === 'install') {

--- a/src/background.js
+++ b/src/background.js
@@ -1,7 +1,5 @@
-/* global chrome, browser:true */
-if (typeof chrome !== 'undefined' && chrome) {
-  browser = chrome
-}
+/* global chrome */
+var browser = chrome
 
 browser.runtime.onInstalled.addListener(function (details) {
   if (details.reason === 'install') {


### PR DESCRIPTION
## Change

This seems to be the issue.


Replace `browser = chrome` implicit global with `var browser = chrome` proper
declaration. The implicit global inside webpack's IIFE can fail to register in
Chrome MV3 service worker contexts, causing "Could not load background script".

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

We will wait to see if the extension is accepted in the store.
